### PR TITLE
[utils] Don't add null values to key map

### DIFF
--- a/src/utils/json.cpp
+++ b/src/utils/json.cpp
@@ -21,7 +21,9 @@ CaseInsensitiveObjectWrapper::CaseInsensitiveObjectWrapper(const Poco::JSON::Obj
     : mObject(object)
 {
     for (const auto& pair : *object) {
-        mKeyMap.emplace(ToLowercase(pair.first), pair.first);
+        if (!pair.second.isEmpty()) {
+            mKeyMap.emplace(ToLowercase(pair.first), pair.first);
+        }
     }
 }
 


### PR DESCRIPTION
Has() method returns true while Get() method fails. Skip empty values to avoid check for null in client logic.