### PR TITLE
ci: use aos-core-build image

### DIFF
--- a/.github/workflows/build_test.yaml
+++ b/.github/workflows/build_test.yaml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions: read-all
     container:
-      image: ghcr.io/aosedge/aos-core-build-base:latest
+      image: ghcr.io/aosedge/aos-core-build:latest
       options: "--entrypoint /usr/bin/bash"
       credentials:
         username: ${{ github.actor }}


### PR DESCRIPTION
aos-core-build-base image is deprecated, and does not exist anymore in the registry.