### PR TITLE
ci: use aos-core-build image

### DIFF
--- a/.github/workflows/build_test.yaml
+++ b/.github/workflows/build_test.yaml
@@ -33,10 +33,6 @@ jobs:
       BUILD_WRAPPER_OUT_DIR: build_wrapper_output_directory
 
     steps:
-      # Apply solution to "HOME is overridden for containers" problem: https://github.com/actions/runner/issues/863
-      - name: Preserve $HOME set in the container
-        run: echo HOME=/root >> "$GITHUB_ENV"
-
       - name: Checkout
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/build_test.yaml
+++ b/.github/workflows/build_test.yaml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions: read-all
     container:
-      image: ghcr.io/aosedge/aos-core-build-base:latest
+      image: ghcr.io/aosedge/aos-core-build:latest
       options: "--entrypoint /usr/bin/bash"
       credentials:
         username: ${{ github.actor }}


### PR DESCRIPTION
aos-core-build-base image is deprecated, and does not exist anymore in the registry.